### PR TITLE
Ajout d'un README et d'un script d'installation des dépendances

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Op-ration-Shelfcam
+
+Script de reconnaissance réseau automatique conçu pour être exécuté sur un Raspberry Pi. Il détecte l'interface Wi-Fi active, collecte les informations réseau et lance divers scans pour inventorier les hôtes et services présents sur le réseau cible.
+
+## Installation des dépendances
+
+Un script d'installation (`install.sh`) permet d'installer automatiquement tous les outils requis. Exécutez-le une fois en tant que superutilisateur :
+
+```bash
+sudo ./install.sh
+```
+
+## Pré-requis
+
+Le script repose sur plusieurs outils système. Les binaires suivants doivent être présents :
+
+- `ip`, `nmap`, `arp-scan`, `tcpdump`, `iw`, `jq`
+- Outils optionnels : `nbtscan`, `avahi-browse`
+
+## Configuration
+
+Les paramètres principaux sont définis dans `config.json` :
+
+- `interface` : interface réseau à utiliser (détection automatique si vide)
+- `base_dir` : dossier où seront stockés les résultats
+- `enable_mdns`, `enable_netbios`, `enable_tcpdump` : activation des modules facultatifs
+- `timeouts` : délais d'exécution pour chaque module
+
+## Utilisation
+
+Exécutez le script en tant que superutilisateur :
+
+```bash
+sudo ./recon.sh
+```
+
+Les résultats et journaux sont enregistrés dans un dossier horodaté situé dans `base_dir`. Un fichier `resume.txt` résume les paramètres et le nombre d'hôtes détectés.
+
+## Structure du dépôt
+
+- `recon.sh` : script principal de reconnaissance
+- `config.json` : fichier de configuration
+- `install.sh` : installation des dépendances
+- `README.md` : ce document
+
+## Avertissement
+
+Ce projet est destiné à des exercices Red Team ou à des tests de sécurité autorisés. L'utilisation sur un réseau sans consentement explicite peut être illégale.
+

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$EUID" -ne 0 ]; then
+    echo "Ce script doit être exécuté en root." >&2
+    exit 1
+fi
+
+if ! command -v apt-get >/dev/null 2>&1; then
+    echo "Gestionnaire de paquets 'apt-get' introuvable. Installation manuelle requise." >&2
+    exit 1
+fi
+
+apt-get update
+
+# Paquets obligatoires
+apt-get install -y iproute2 nmap arp-scan tcpdump iw jq
+
+# Paquets optionnels (échec non bloquant)
+if ! apt-get install -y nbtscan avahi-utils; then
+    echo "Installation des outils optionnels échouée, le script fonctionnera sans eux." >&2
+fi
+
+echo "Installation des dépendances terminée."


### PR DESCRIPTION
## Summary
- Ajout d'un README en français décrivant le script `recon.sh`, ses dépendances et son utilisation
- Ajout d'un script `install.sh` pour installer automatiquement les dépendances requises

## Testing
- `bash -n install.sh`
- `bash -n recon.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c6e2d863688324a6a2f978fb7c4f39