### PR TITLE
Fix nmap port parsing in phase 1 recon script

### DIFF
--- a/recon-phase1.sh
+++ b/recon-phase1.sh
@@ -231,7 +231,7 @@ if [[ -f "$OUTPUT_DIR/nmap-detailed.txt" ]]; then
     ip=$(echo "$line" | awk '{print $2}')
     ports=$(echo "$line" | awk -F"Ports: " '{print $2}')
     [[ -z "$ip" || -z "$ports" ]] && continue
-    PORTS[$ip]=$(echo "$ports" | sed 's#/open/[^ ]*##g' | sed 's/[[:space:]]*Ignored.*$//' | tr ' ' ',')
+      PORTS[$ip]=$(echo "$ports" | grep -oE '[0-9]+/(open|filtered)' | cut -d'/' -f1 | tr '\n' ',' | sed 's/,$//')
     echo "$ip ${PORTS[$ip]:-""}" >> "$OUTPUT_DIR/port-summary.txt"
   done < <(grep "Ports:" "$OUTPUT_DIR/nmap-detailed.txt")
 else


### PR DESCRIPTION
## Summary
- handle nmap port list parsing using grep/cut pipeline to generate comma separated ports

## Testing
- `shellcheck recon-phase1.sh`
- `bash -n recon-phase1.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c7208100688324a64011a064bbba77